### PR TITLE
Add range syntax and examples.

### DIFF
--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -52,6 +52,9 @@ Control expressions:
     }
 
     for i in [1, 2, 3, 4] {
+        for j in [1, 3, ... 11] {
+            b = a + j
+        }
         if i == 2 {
             continue
         }

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -21,13 +21,14 @@ params := (expr ',')* (expr | null)
 flagexpr := 'true' | 'false' | call | ('(' flagexpr ')')
           | ('not' flagexpr) | (flagexpr ('and' | 'or') flagexpr)
           | (numexpr ('<' | '>' | '<=' | '>=' | '==' | '!=' ) numexpr)
-listlike := listexpr | strexpr
+listlike := listexpr | strexpr | rangeexpr
 listexpr := ('[' (expr ',')* (expr | null) ']') | call
           | (listexpr '+' expr) | (listexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
 funcexpr := '(' (ident ',')* (ident | null) ')' '{' statement* '}'
 numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%] numexpr)
 strexpr := string | call | (strexpr '+' strexpr)
          | (strexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
+rangeexpr := '[' number ',' number ',' '...' number ']'
 
 number := '-'? numeral+ ('.' numeral+)?
 string := ''' [^']* '''


### PR DESCRIPTION
Currently intended to parse arithmetic progressions like 1, 3, ... 11 or 10, 7, ... -2. Should we include support for more complex progressions or would that add unnecessary complexity?