### PR TITLE
Additional language features and minor improvements.

### DIFF
--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -1,27 +1,28 @@
 Examples of GoDlang as described in lang_spec:
 
 Declarations and assignments:
+    # comment
     num foo = -3.452
     str bar = 'hello world'
     str empty-for-now
     flag is-good = true
     empty-for-now = 'not empty anymore'
-    
+
     list baz = [
         foo,
         [14, is-good],
         is-good,
         foo
     ]
-    
-    func do-summat = (a, b, c) {
+
+    func do-summat = (num a, num b, num c) {
         num abc = a
         b = c
         return c
     }
 
 Things you can do with variables:
-    num a = 3 + 5.7
+    num a = (3 + 5.7) ^ 2
     num b = (a - 23) % 6
     str c = 'abcdef' + 'ghi'
 

--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -5,7 +5,7 @@ Declarations and assignments:
     num foo = -3.452
     str bar = 'hello world'
     str empty-for-now
-    flag is-good = true
+    bool is-good = true
     empty-for-now = 'not empty anymore'
 
     list baz = [
@@ -15,7 +15,7 @@ Declarations and assignments:
         foo
     ]
 
-    func do-summat = (num a, num b, num c) {
+    func do-summat = (num a, num b, num c) -> num {
         num abc = a
         b = c
         return c
@@ -26,13 +26,13 @@ Things you can do with variables:
     num b = (a - 23) % 6
     str c = 'abcdef' + 'ghi'
 
-    flag really-good = baz[2]
+    bool really-good = baz[2]
     really-good = baz[-2]
     list another-baz = baz[1:4]
     str not-c = c[-1:-3]
     str still-not-c = c[:2] + c[4:]
 
-    flag really-good = (not (a > b)) and (c[5] == 'k')
+    bool really-good = (not (a > b)) and (c[5] == 'k')
         or (a * 3.4 <= 42) or (baz[1] != baz[-4])
     b = do-summat(0, 0, 0)
 

--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -6,7 +6,7 @@ Declarations and assignments:
     str bar = 'hello world'
     str empty-for-now
     bool is-good = true
-    empty-for-now = 'not empty anymore'
+    empty-for-now = 'not empty anymore' # yet another comment
 
     list baz = [
         foo,

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -14,7 +14,7 @@ elseclause := 'else' '{' statement* '}'
 whilectrl := 'while' flagexpr '{' statement* '}'
 forctrl := 'for' ident 'in' listlike '{' statement* '}'
 
-type := 'num' | 'str' | 'flag' | 'list' | 'func'
+type := 'num' | 'str' | 'bool' | 'list' | 'func'
 ident := [0-9a-zA-Z_-]+
 expr := numexpr | flagexpr | funcexpr
       | listlike | (listlike '[' '-'? numeral+ ']')
@@ -26,7 +26,7 @@ flagexpr := 'true' | 'false' | call | ('(' flagexpr ')')
 listlike := listexpr | strexpr | rangeexpr
 listexpr := ('[' (expr ',')* (expr | null) ']') | call
           | (listexpr '+' expr) | (listexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
-funcexpr := '(' (type ident ',')* (type ident | null) ')' '{' statement* '}'
+funcexpr := '(' (type ident ',')* (type ident | null) ')' ( '->' type )? '{' statement* '}'
 numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%^] numexpr)
 strexpr := string | call | (strexpr '+' strexpr)
          | (strexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -1,10 +1,11 @@
 statement := (declaration | assignment | call | control) '\n'
 
-declaration := ('num' | 'str' | 'flag' | 'list' | 'func') ident ('=' expr)?
+declaration := type ident ('=' expr)?
 assignment := ident '=' expr
 call := ident '(' params ')'
 control := ifctrl | whilectrl | forctrl
          | ('return' expr) | 'break' | 'continue'
+comment := '#' string
 
 ifctrl := ifclause elifclause* elseclause?
 ifclause := 'if' flagexpr '{' statement* '}'
@@ -13,6 +14,7 @@ elseclause := 'else' '{' statement* '}'
 whilectrl := 'while' flagexpr '{' statement* '}'
 forctrl := 'for' ident 'in' listlike '{' statement* '}'
 
+type := 'num' | 'str' | 'flag' | 'list' | 'func'
 ident := [0-9a-zA-Z_-]+
 expr := numexpr | flagexpr | funcexpr
       | listlike | (listlike '[' '-'? numeral+ ']')
@@ -24,8 +26,8 @@ flagexpr := 'true' | 'false' | call | ('(' flagexpr ')')
 listlike := listexpr | strexpr | rangeexpr
 listexpr := ('[' (expr ',')* (expr | null) ']') | call
           | (listexpr '+' expr) | (listexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
-funcexpr := '(' (ident ',')* (ident | null) ')' '{' statement* '}'
-numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%] numexpr)
+funcexpr := '(' (type ident ',')* (type ident | null) ')' '{' statement* '}'
+numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%^] numexpr)
 strexpr := string | call | (strexpr '+' strexpr)
          | (strexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
 rangeexpr := '[' number ',' number ',' '...' number ']'

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -1,4 +1,5 @@
-statement := (declaration | assignment | call | control) '\n'
+statement := (declaration | assignment | call | control | comment
+           | ((declaration | assignment | call | control) comment)) '\n'
 
 declaration := type ident ('=' expr)?
 assignment := ident '=' expr


### PR DESCRIPTION
* Add support for exponents using the '^' operator.
* Add support for comments. Everything on a line after a '#' character should be ignored.
* Improve function declaration syntax. Functions must now declare the data types of their parameters during function declaration.

Should functions also define a return type? In that case, do not merge. Proposed syntax for defining return types:
`func aFunction = (num param) -> (num) {  ....  }`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/game-of-death/docs/6)
<!-- Reviewable:end -->
