### PR TITLE
Add structs and improve function declaration syntax.

### DIFF
--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -8,17 +8,27 @@ Declarations and assignments:
     bool is-good = true
     empty-for-now = 'not empty anymore' # yet another comment
 
-    list baz = [
-        foo,
-        [14, is-good],
+    [bool] baz = [
+        true,
+        false,
         is-good,
-        foo
+        (not is-good)
     ]
 
-    func do-summat = (num a, num b, num c) -> num {
+    func do-summat (num a, num b, num c) -> num {
         num abc = a
         b = c
         return c
+    }
+
+    func voidFunc (num number, {(num, num) -> num} funcToCall) {
+        foo = funcToCall(1, 2) + number
+    }
+
+    struct person = {
+        str name
+        num contact
+        {(num, bool) -> [str]} aFunction
     }
 
 Things you can do with variables:
@@ -28,7 +38,7 @@ Things you can do with variables:
 
     bool really-good = baz[2]
     really-good = baz[-2]
-    list another-baz = baz[1:4]
+    [bool] another-baz = baz[1:4]
     str not-c = c[-1:-3]
     str still-not-c = c[:2] + c[4:]
 
@@ -47,7 +57,7 @@ Control expressions:
     if (2 < 3) {
         do-summat(1, 2, 3)
     } else {
-        func call-later = do-summat
+        {(num, num, num) -> num} call-later = do-summat
         b = do-summat(4, 5, 6)
         call-later(a, b, 4)
     }

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -1,12 +1,13 @@
-statement := (declaration | assignment | call | control | comment
-           | ((declaration | assignment | call | control) comment)) '\n'
+statement := (instruction | comment | (instruction comment)) '\n'
+
+instruction := declaration | assignment | call | control | funcdef
+comment := '#' string
 
 declaration := type ident ('=' expr)?
 assignment := ident '=' expr
 call := ident '(' params ')'
 control := ifctrl | whilectrl | forctrl
          | ('return' expr) | 'break' | 'continue'
-comment := '#' string
 
 ifctrl := ifclause elifclause* elseclause?
 ifclause := 'if' flagexpr '{' statement* '}'
@@ -15,9 +16,13 @@ elseclause := 'else' '{' statement* '}'
 whilectrl := 'while' flagexpr '{' statement* '}'
 forctrl := 'for' ident 'in' listlike '{' statement* '}'
 
-type := 'num' | 'str' | 'bool' | 'list' | 'func'
+type := datatype | functype
+datatype := 'num' | 'str' | 'bool' | ('[' datatype ']') | 'struct'
+funcdef := 'func' ident '(' (type ident ',')*  (type ident | null) ')' -> datatype '{' statement* '}'
+functype := '{' '(' (type ',')* (type | null) ')' '->' (datatype | '()') '}'
+
 ident := [0-9a-zA-Z_-]+
-expr := numexpr | flagexpr | funcexpr
+expr := numexpr | flagexpr | funcexpr | structexpr
       | listlike | (listlike '[' '-'? numeral+ ']')
 params := (expr ',')* (expr | null)
 
@@ -27,10 +32,10 @@ flagexpr := 'true' | 'false' | call | ('(' flagexpr ')')
 listlike := listexpr | strexpr | rangeexpr
 listexpr := ('[' (expr ',')* (expr | null) ']') | call
           | (listexpr '+' expr) | (listexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
-funcexpr := '(' (type ident ',')* (type ident | null) ')' ( '->' type )? '{' statement* '}'
 numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%^] numexpr)
 strexpr := string | call | (strexpr '+' strexpr)
          | (strexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
+structexpr := '{' (type ident)* '}'
 rangeexpr := '[' number ',' number ',' '...' number ']'
 
 number := '-'? numeral+ ('.' numeral+)?


### PR DESCRIPTION
* Add support for structs.
* Improve function declaration syntax.
* Introduce "function types", which replace the old 'func' data type and are more specific.

TODO: Improve the representation of function types. Currently the function type of functions from `(num, num)` to `str` is represented as `{(num, num) -> str}`. This may not read too well. Need to discuss better ways to represent function types.

The TODO wouldn't be required if variables/params were defined as `name: type = val` as in JS, Golang or Swift. Might want to skim through [this page](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Functions.html) for how Swift deals with function types, functions as parameters of other functions, and functions in general (in my opinion Swift does the best job of dealing with this stuff).

Signed-off-by: mandarj7 <mjuvekar7@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/game-of-death/docs/7)
<!-- Reviewable:end -->