### PR TITLE
Implicit func typing

### DIFF
--- a/spec/lang/lang_egs
+++ b/spec/lang/lang_egs
@@ -16,14 +16,14 @@ Declarations and assignments:
     ]
     baz[1] = not baz[1]
 
-    [str : bool] isTasty = [
-        'pepperoni' : true,
-        'pizza' : true,
-        'orange' : true,
-        'banana' : true,
-        'broccoli' : false
+    [str:bool] isTasty = [
+        'pepperoni': true,
+        'pizza':     true,
+        'orange':    true,
+        'banana':    true,
+        'broccoli':  false
     ]
-    isTasty['banana'] = false
+    isTasty['banana'] = baz[0]
 
     func do-summat (num a, num b, num c) -> num {
         num abc = a
@@ -67,7 +67,7 @@ Control expressions:
     if (2 < 3) {
         do-summat(1, 2, 3)
     } else {
-        {(num, num, num) -> num} call-later = do-summat
+        func call-later = do-summat   # you can use the explicit {} functype syntax if you want
         b = do-summat(4, 5, 6)
         call-later(a, b, 4)
     }

--- a/spec/lang/lang_spec
+++ b/spec/lang/lang_spec
@@ -19,24 +19,24 @@ forctrl := 'for' ident 'in' listlike '{' statement* '}'
 type := datatype | functype
 datatype := 'num' | 'str' | 'bool' | ('[' datatype ']') | 'struct'
           | ('[' datatype ':' datatype ']')
-funcdef := 'func' ident '(' (type ident ',')*  (type ident | null) ')' -> datatype '{' statement* '}'
-functype := '{' '(' (type ',')* (type | null) ')' '->' (datatype | '()') '}'
+funcdef := 'func' ident '(' (type ident ',')*  (type ident | null) ')' ('->' datatype)? '{' statement* '}'
+functype := ('{' (('(' (type ',')* type) | null) ')' ('->' datatype)? '}') | 'func'
 
 ident := [0-9a-zA-Z_-]+
 expr := numexpr | boolexpr | structexpr | listlike
       | (listlike '[' '-'? numeral+ ']')
-params := (expr ',')* (expr | null)
+params := ((expr ',')* expr) | null
 
 boolexpr := 'true' | 'false' | call | ('(' boolexpr ')')
           | ('not' boolexpr) | (boolexpr ('and' | 'or') boolexpr)
           | (numexpr ('<' | '>' | '<=' | '>=' | '==' | '!=' ) numexpr)
 listlike := listexpr | strexpr | rangeexpr
-listexpr := ('[' (expr ',')* (expr | null) ']') | call
+listexpr := ('[' (((expr ',')* expr) | null) ']') | call
           | (listexpr '+' expr) | (listexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
 numexpr := number | call | '(' numexpr ')' | (numexpr [-+*/%^] numexpr)
 strexpr := string | call | (strexpr '+' strexpr)
          | (strexpr '[' ('-'? numeral+)? ':' ('-'? numeral+)? ']')
-dictexpr := ('[' (expr ':' expr ',')* ((expr ':' expr) | null) ']') | call
+dictexpr := ('[' (((expr ':' expr ',')* (expr ':' expr)) | null) ']') | call
 structexpr := '{' (type ident)* '}' | call
 rangeexpr := '[' number ',' number ',' '...' number ']'
 


### PR DESCRIPTION
Add the keyword `func` as a type for use in expressions like `func a = b` where implicit
typing might be preferable. Minor changes in examples.